### PR TITLE
don't run lint*, just lint

### DIFF
--- a/taskcluster/xpi_taskgraph/xpi_manifest.py
+++ b/taskcluster/xpi_taskgraph/xpi_manifest.py
@@ -79,7 +79,7 @@ def get_manifest():
             with open(os.path.join(dir_name, "package.json")) as fh:
                 package_json = json.load(fh)
             for target in package_json.get("scripts", {}):
-                if target.startswith("test") or target.startswith("lint"):
+                if target.startswith("test") or target == "lint":
                     manifest["tests"].append(target)
             manifest["name"] = package_json["name"].lower()
             manifest_list.append(ReadOnlyDict(manifest))


### PR DESCRIPTION
We'll need to update the source repos to use the new `.taskcluster.yml` to pick up this change.