### PR TITLE
Private repo CI

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -6,15 +6,15 @@ policy:
 tasks:
     - $let:
           taskgraph:
-              branch: taskgraph
-              revision: c78d65237c6ed064b9cbb3cd063b22e9e052a06a
+              branch: taskgraph-try
+              revision: 5af31e64fb97594e6064e87bbfb3ab0a5fade7ec
           template:
               repo: https://github.com/mozilla-extensions/xpi-template
               branch: master
           trustDomain: xpi
           # XXX for private repos, uncomment this line, and comment out the next
-          # githubCloneSecret: project/xpi/xpi-github-clone-ssh
-          githubCloneSecret: ""
+          # xpiSshSecretName: project/xpi/xpi-github-clone-ssh
+          xpiSshSecretName: ""
           # XXX use "privileged" or "system" to enable signing
           xpiSigningType: ""
       in:
@@ -193,7 +193,7 @@ tasks:
                                     TASKGRAPH_REPOSITORY_TYPE: hg
                                     REPOSITORIES: {$json: {xpi: "XPI Manifest", taskgraph: "Taskgraph", template: "XPI Template"}}
                                     HG_STORE_PATH: /builds/worker/checkouts/hg-store
-                                    GITHUB_CLONE_SECRET: '${githubCloneSecret}'
+                                    XPI_SSH_SECRET_NAME: '${xpiSshSecretName}'
                                   - $if: 'tasks_for in ["github-pull-request"]'
                                     then:
                                         XPI_PULL_REQUEST_NUMBER: '${event.pull_request.number}'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -2,7 +2,7 @@
 version: 1
 reporting: checks-v1
 policy:
-    pullRequests: public
+    pullRequests: collaborators
 tasks:
     - $let:
           taskgraph:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -6,8 +6,8 @@ policy:
 tasks:
     - $let:
           taskgraph:
-              branch: taskgraph-try
-              revision: 5af31e64fb97594e6064e87bbfb3ab0a5fade7ec
+              branch: taskgraph
+              revision: 7dde9ce7740068d7b73218976343a28fc99be847
           template:
               #XXX uncomment to merge
               #repo: https://github.com/mozilla-extensions/xpi-template

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -142,7 +142,7 @@ tasks:
                                 then:
                                     source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
                                 else:
-
+                                    # XXX revisit after https://github.com/taskcluster/taskcluster/pull/2812
                                     source: 'https://github.com/${repoUrl[15:-4]}/raw/${head_sha}/.taskcluster.yml'
                               - $if: 'tasks_for in ["github-push", "github-pull-request"]'
                                 then:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -16,7 +16,7 @@ tasks:
               branch: private-ci
           trustDomain: xpi
           # XXX for private repos, uncomment this line, and comment out the next
-          # xpiSshSecretName: project/xpi/xpi-github-clone-ssh
+          #xpiSshSecretName: project/xpi/xpi-github-clone-ssh
           xpiSshSecretName: ""
           # XXX use "privileged" or "system" to enable signing
           xpiSigningType: ""
@@ -79,7 +79,7 @@ tasks:
                               # Trim https://github.com/
                               then: '${repository.url[19:]}'
                   baseRepoUrl:
-                      $if: '${xpiSshSecretName} == ""'  # public repo
+                      $if: '!xpiSshSecretName'  # public repo
                       then:
                           $if: 'tasks_for == "github-push"'
                           then: '${event.repository.html_url}'
@@ -99,7 +99,7 @@ tasks:
                                   $if: 'tasks_for in ["cron", "action"]'
                                   then: '${repository.url}'
                   repoUrl:
-                      $if: '${xpiSshSecretName} == ""'  # public repo
+                      $if: '!xpiSshSecretName'  # public repo
                       then:
                           $if: 'tasks_for == "github-push"'
                           then: '${event.repository.html_url}'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -9,8 +9,11 @@ tasks:
               branch: taskgraph-try
               revision: 5af31e64fb97594e6064e87bbfb3ab0a5fade7ec
           template:
-              repo: https://github.com/mozilla-extensions/xpi-template
-              branch: master
+              #XXX uncomment to merge
+              #repo: https://github.com/mozilla-extensions/xpi-template
+              #branch: master
+              repo: https://github.com/escapewindow/xpi-template
+              branch: private-ci
           trustDomain: xpi
           # XXX for private repos, uncomment this line, and comment out the next
           # xpiSshSecretName: project/xpi/xpi-github-clone-ssh

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -212,7 +212,7 @@ tasks:
                           # Note: This task is built server side without the context or tooling that
                           # exist in tree so we must hard code the hash
                           image:
-                              mozillareleases/taskgraph:decision-bd477b55732fc5f5d55a78e6162355af8bc81805b415a9ea8dbe42c020f840db
+                              mozillareleases/taskgraph:decision-21bef1bc0f11e62c7a23384584f9f8f0d96e95eef192e5bb599fc82ba55c81a7@sha256:d29af306b09cd00a63f982e8caeb53dbec7efd7bb3ae64ce3cef9cd889b750e6
 
                           maxRunTime: 1800
 

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -138,7 +138,12 @@ tasks:
                       metadata:
                           $merge:
                               - owner: "${ownerEmail}"
-                                source: 'https://github.com/${repoUrl[15:-4]}/raw/${head_sha}/.taskcluster.yml'
+                              - $if: '!xpiSshSecretName'  # public repo
+                                then:
+                                    source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
+                                else:
+
+                                    source: 'https://github.com/${repoUrl[15:-4]}/raw/${head_sha}/.taskcluster.yml'
                               - $if: 'tasks_for in ["github-push", "github-pull-request"]'
                                 then:
                                     name: "Decision Task"

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -24,103 +24,100 @@ tasks:
           $if: 'tasks_for in ["github-pull-request", "github-push", "action", "cron"]'
           then:
               $let:
-                  $flatten:
-                      # Github events have this stuff in different places...
-                      ownerEmail:
-                          $if: 'tasks_for == "github-push"'
-                          then: '${event.pusher.email}'
-                          # Assume Pull Request
-                          else:
-                              $if: 'tasks_for == "github-pull-request"'
-                              then: '${event.pull_request.user.login}@users.noreply.github.com'
-                              else:
-                                  $if: 'tasks_for in ["cron", "action"]'
-                                  then: '${tasks_for}@noreply.mozilla.org'
-                      project:
-                          $if: 'tasks_for == "github-push"'
-                          then: '${event.repository.name}'
-                          else:
-                              $if: 'tasks_for == "github-pull-request"'
-                              then: '${event.pull_request.head.repo.name}'
-                              else:
-                                  $if: 'tasks_for in ["cron", "action"]'
-                                  then: '${repository.project}'
-                      head_branch:
+                  # Github events have this stuff in different places...
+                  ownerEmail:
+                      $if: 'tasks_for == "github-push"'
+                      then: '${event.pusher.email}'
+                      # Assume Pull Request
+                      else:
                           $if: 'tasks_for == "github-pull-request"'
-                          then: ${event.pull_request.head.ref}
-                          else:
-                              $if: 'tasks_for == "github-push"'
-                              then: ${event.ref}
-                              else:
-                                  $if: 'tasks_for == "cron"'
-                                  then: '${push.branch}'
-                                  else:
-                                      $if: 'tasks_for == "action"'
-                                      then: 'refs/heads/master'  # TODO fix
-                      head_sha:
-                          $if: 'tasks_for == "github-push"'
-                          then: '${event.after}'
-                          else:
-                              $if: 'tasks_for == "github-pull-request"'
-                              then: '${event.pull_request.head.sha}'
-                              else:
-                                  $if: 'tasks_for in ["cron", "action"]'
-                                  then: '${push.revision}'
-                      ownTaskId:
-                          $if: '"github" in tasks_for'
-                          then: {$eval: as_slugid("decision_task")}
+                          then: '${event.pull_request.user.login}@users.noreply.github.com'
                           else:
                               $if: 'tasks_for in ["cron", "action"]'
-                              then: '${ownTaskId}'
-                      repoFullName:
-                          $if: 'tasks_for in "github-push"'
-                          then: '${event.repository.full_name}'
+                              then: '${tasks_for}@noreply.mozilla.org'
+                  project:
+                      $if: 'tasks_for == "github-push"'
+                      then: '${event.repository.name}'
+                      else:
+                          $if: 'tasks_for == "github-pull-request"'
+                          then: '${event.pull_request.head.repo.name}'
                           else:
-                              $if: 'tasks_for == "github-pull-request"'
-                              then: '${event.pull_request.base.repo.full_name}'
-                              else:
-                                  $if: 'tasks_for in ["cron", "action"]'
-                                  # Trim https://github.com/
-                                  then: '${repository.url[19:]}'
+                              $if: 'tasks_for in ["cron", "action"]'
+                              then: '${repository.project}'
+                  head_branch:
+                      $if: 'tasks_for == "github-pull-request"'
+                      then: ${event.pull_request.head.ref}
+                      else:
+                          $if: 'tasks_for == "github-push"'
+                          then: ${event.ref}
+                          else:
+                              $if: 'tasks_for in ["cron", "action"]'
+                              then: '${push.branch}'
+                  head_sha:
+                      $if: 'tasks_for == "github-push"'
+                      then: '${event.after}'
+                      else:
+                          $if: 'tasks_for == "github-pull-request"'
+                          then: '${event.pull_request.head.sha}'
+                          else:
+                              $if: 'tasks_for in ["cron", "action"]'
+                              then: '${push.revision}'
+                  ownTaskId:
+                      $if: '"github" in tasks_for'
+                      then: {$eval: as_slugid("decision_task")}
+                      else:
+                          $if: 'tasks_for in ["cron", "action"]'
+                          then: '${ownTaskId}'
+                  repoFullName:
+                      $if: 'tasks_for in "github-push"'
+                      then: '${event.repository.full_name}'
+                      else:
+                          $if: 'tasks_for == "github-pull-request"'
+                          then: '${event.pull_request.base.repo.full_name}'
+                          else:
+                              $if: 'tasks_for in ["cron", "action"]'
+                              # Trim https://github.com/
+                              then: '${repository.url[19:]}'
+                  baseRepoUrl:
                       $if: '${xpiSshSecretName} == ""'  # public repo
                       then:
-                          baseRepoUrl:
-                              $if: 'tasks_for == "github-push"'
-                              then: '${event.repository.html_url}'
+                          $if: 'tasks_for == "github-push"'
+                          then: '${event.repository.html_url}'
+                          else:
+                              $if: 'tasks_for == "github-pull-request"'
+                              then: '${event.pull_request.base.repo.html_url}'
                               else:
-                                  $if: 'tasks_for == "github-pull-request"'
-                                  then: '${event.pull_request.base.repo.html_url}'
-                                  else:
-                                      $if: 'tasks_for in ["cron", "action"]'
-                                      then: '${repository.url}'
-                          repoUrl:
-                              $if: 'tasks_for == "github-push"'
-                              then: '${event.repository.html_url}'
-                              else:
-                                  $if: 'tasks_for == "github-pull-request"'
-                                  then: '${event.pull_request.head.repo.html_url}'
-                                  else:
-                                      $if: 'tasks_for in ["cron", "action"]'
-                                      then: '${repository.url}'
+                                  $if: 'tasks_for in ["cron", "action"]'
+                                  then: '${repository.url}'
                       else:
-                          baseRepoUrl:
-                              $if: 'tasks_for == "github-push"'
-                              then: '${event.repository.ssh_url}'
+                          $if: 'tasks_for == "github-push"'
+                          then: '${event.repository.ssh_url}'
+                          else:
+                              $if: 'tasks_for == "github-pull-request"'
+                              then: '${event.pull_request.base.repo.ssh_url}'
                               else:
-                                  $if: 'tasks_for == "github-pull-request"'
-                                  then: '${event.pull_request.base.repo.ssh_url}'
-                                  else:
-                                      $if: 'tasks_for in ["cron", "action"]'
-                                      then: '${repository.url}'
-                          repoUrl:
-                              $if: 'tasks_for == "github-push"'
-                              then: '${event.repository.ssh_url}'
+                                  $if: 'tasks_for in ["cron", "action"]'
+                                  then: '${repository.url}'
+                  repoUrl:
+                      $if: '${xpiSshSecretName} == ""'  # public repo
+                      then:
+                          $if: 'tasks_for == "github-push"'
+                          then: '${event.repository.html_url}'
+                          else:
+                              $if: 'tasks_for == "github-pull-request"'
+                              then: '${event.pull_request.head.repo.html_url}'
                               else:
-                                  $if: 'tasks_for == "github-pull-request"'
-                                  then: '${event.pull_request.base.repo.ssh_url}'
-                                  else:
-                                      $if: 'tasks_for in ["cron", "action"]'
-                                      then: '${repository.url}'
+                                  $if: 'tasks_for in ["cron", "action"]'
+                                  then: '${repository.url}'
+                      else:
+                          $if: 'tasks_for == "github-push"'
+                          then: '${event.repository.ssh_url}'
+                          else:
+                              $if: 'tasks_for == "github-pull-request"'
+                              then: '${event.pull_request.base.repo.ssh_url}'
+                              else:
+                                  $if: 'tasks_for in ["cron", "action"]'
+                                  then: '${repository.url}'
               in:
                   $let:
                       level: 1

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -5,21 +5,20 @@ policy:
     pullRequests: collaborators
 tasks:
     - $let:
+          # XXX Set to `true` for private repos
+          privateRepo: false
+          # XXX use "privileged" or "system" to enable dep-signing on push / PR.
+          #     This only works for public repos for now. Release builds off
+          #     shipit will get signing for both public and private repos.
+          xpiSigningType: ""
+          # The below doesn't need changing on initial repo setup
           taskgraph:
               branch: taskgraph
               revision: 7dde9ce7740068d7b73218976343a28fc99be847
           template:
-              #XXX uncomment to merge
-              #repo: https://github.com/mozilla-extensions/xpi-template
-              #branch: master
-              repo: https://github.com/escapewindow/xpi-template
-              branch: private-ci
+              repo: https://github.com/mozilla-extensions/xpi-template
+              branch: master
           trustDomain: xpi
-          # XXX for private repos, uncomment this line, and comment out the next
-          #xpiSshSecretName: project/xpi/xpi-github-clone-ssh
-          xpiSshSecretName: ""
-          # XXX use "privileged" or "system" to enable signing
-          xpiSigningType: ""
       in:
           $if: 'tasks_for in ["github-pull-request", "github-push", "action", "cron"]'
           then:
@@ -79,7 +78,7 @@ tasks:
                               # Trim https://github.com/
                               then: '${repository.url[19:]}'
                   baseRepoUrl:
-                      $if: '!xpiSshSecretName'  # public repo
+                      $if: '!privateRepo'  # public repo
                       then:
                           $if: 'tasks_for == "github-push"'
                           then: '${event.repository.html_url}'
@@ -99,7 +98,7 @@ tasks:
                                   $if: 'tasks_for in ["cron", "action"]'
                                   then: '${repository.url}'
                   repoUrl:
-                      $if: '!xpiSshSecretName'  # public repo
+                      $if: '!privateRepo'  # public repo
                       then:
                           $if: 'tasks_for == "github-push"'
                           then: '${event.repository.html_url}'
@@ -138,11 +137,12 @@ tasks:
                       metadata:
                           $merge:
                               - owner: "${ownerEmail}"
-                              - $if: '!xpiSshSecretName'  # public repo
+                              - $if: '!privateRepo'  # public repo
                                 then:
                                     source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
                                 else:
                                     # XXX revisit after https://github.com/taskcluster/taskcluster/pull/2812
+                                    #     is deployed to the firefoxci cluster.
                                     source: 'https://github.com/${repoUrl[15:-4]}/raw/${head_sha}/.taskcluster.yml'
                               - $if: 'tasks_for in ["github-push", "github-pull-request"]'
                                 then:
@@ -233,7 +233,9 @@ tasks:
                                     TASKGRAPH_REPOSITORY_TYPE: hg
                                     REPOSITORIES: {$json: {xpi: "XPI Manifest", taskgraph: "Taskgraph", template: "XPI Template"}}
                                     HG_STORE_PATH: /builds/worker/checkouts/hg-store
-                                    XPI_SSH_SECRET_NAME: '${xpiSshSecretName}'
+                                  - $if: 'privateRepo'
+                                    then:
+                                        XPI_SSH_SECRET_NAME: project/xpi/xpi-github-clone-ssh
                                   - $if: 'tasks_for in ["github-pull-request"]'
                                     then:
                                         XPI_PULL_REQUEST_NUMBER: '${event.pull_request.number}'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -24,71 +24,103 @@ tasks:
           $if: 'tasks_for in ["github-pull-request", "github-push", "action", "cron"]'
           then:
               $let:
-                  # Github events have this stuff in different places...
-                  ownerEmail:
-                      $if: 'tasks_for == "github-push"'
-                      then: '${event.pusher.email}'
-                      # Assume Pull Request
-                      else:
-                          $if: 'tasks_for == "github-pull-request"'
-                          then: '${event.pull_request.user.login}@users.noreply.github.com'
-                          else:
-                              $if: 'tasks_for in ["cron", "action"]'
-                              then: '${tasks_for}@noreply.mozilla.org'
-                  baseRepoUrl:
-                      $if: 'tasks_for == "github-push"'
-                      then: '${event.repository.html_url}'
-                      else:
-                          $if: 'tasks_for == "github-pull-request"'
-                          then: '${event.pull_request.base.repo.html_url}'
-                          else:
-                              $if: 'tasks_for in ["cron", "action"]'
-                              then: '${repository.url}'
-                  repoUrl:
-                      $if: 'tasks_for == "github-push"'
-                      then: '${event.repository.html_url}'
-                      else:
-                          $if: 'tasks_for == "github-pull-request"'
-                          then: '${event.pull_request.head.repo.html_url}'
-                          else:
-                              $if: 'tasks_for in ["cron", "action"]'
-                              then: '${repository.url}'
-                  project:
-                      $if: 'tasks_for == "github-push"'
-                      then: '${event.repository.name}'
-                      else:
-                          $if: 'tasks_for == "github-pull-request"'
-                          then: '${event.pull_request.head.repo.name}'
-                          else:
-                              $if: 'tasks_for in ["cron", "action"]'
-                              then: '${repository.project}'
-                  head_branch:
-                      $if: 'tasks_for == "github-pull-request"'
-                      then: ${event.pull_request.head.ref}
-                      else:
+                  $flatten:
+                      # Github events have this stuff in different places...
+                      ownerEmail:
                           $if: 'tasks_for == "github-push"'
-                          then: ${event.ref}
+                          then: '${event.pusher.email}'
+                          # Assume Pull Request
                           else:
-                              $if: 'tasks_for == "cron"'
-                              then: '${push.branch}'
+                              $if: 'tasks_for == "github-pull-request"'
+                              then: '${event.pull_request.user.login}@users.noreply.github.com'
                               else:
-                                  $if: 'tasks_for == "action"'
-                                  then: 'refs/heads/master'  # TODO fix
-                  head_sha:
-                      $if: 'tasks_for == "github-push"'
-                      then: '${event.after}'
-                      else:
+                                  $if: 'tasks_for in ["cron", "action"]'
+                                  then: '${tasks_for}@noreply.mozilla.org'
+                      project:
+                          $if: 'tasks_for == "github-push"'
+                          then: '${event.repository.name}'
+                          else:
+                              $if: 'tasks_for == "github-pull-request"'
+                              then: '${event.pull_request.head.repo.name}'
+                              else:
+                                  $if: 'tasks_for in ["cron", "action"]'
+                                  then: '${repository.project}'
+                      head_branch:
                           $if: 'tasks_for == "github-pull-request"'
-                          then: '${event.pull_request.head.sha}'
+                          then: ${event.pull_request.head.ref}
+                          else:
+                              $if: 'tasks_for == "github-push"'
+                              then: ${event.ref}
+                              else:
+                                  $if: 'tasks_for == "cron"'
+                                  then: '${push.branch}'
+                                  else:
+                                      $if: 'tasks_for == "action"'
+                                      then: 'refs/heads/master'  # TODO fix
+                      head_sha:
+                          $if: 'tasks_for == "github-push"'
+                          then: '${event.after}'
+                          else:
+                              $if: 'tasks_for == "github-pull-request"'
+                              then: '${event.pull_request.head.sha}'
+                              else:
+                                  $if: 'tasks_for in ["cron", "action"]'
+                                  then: '${push.revision}'
+                      ownTaskId:
+                          $if: '"github" in tasks_for'
+                          then: {$eval: as_slugid("decision_task")}
                           else:
                               $if: 'tasks_for in ["cron", "action"]'
-                              then: '${push.revision}'
-                  ownTaskId:
-                      $if: '"github" in tasks_for'
-                      then: {$eval: as_slugid("decision_task")}
+                              then: '${ownTaskId}'
+                      repoFullName:
+                          $if: 'tasks_for in "github-push"'
+                          then: '${event.repository.full_name}'
+                          else:
+                              $if: 'tasks_for == "github-pull-request"'
+                              then: '${event.pull_request.base.repo.full_name}'
+                              else:
+                                  $if: 'tasks_for in ["cron", "action"]'
+                                  # Trim https://github.com/
+                                  then: '${repository.url[19:]}'
+                      $if: '${xpiSshSecretName} == ""'  # public repo
+                      then:
+                          baseRepoUrl:
+                              $if: 'tasks_for == "github-push"'
+                              then: '${event.repository.html_url}'
+                              else:
+                                  $if: 'tasks_for == "github-pull-request"'
+                                  then: '${event.pull_request.base.repo.html_url}'
+                                  else:
+                                      $if: 'tasks_for in ["cron", "action"]'
+                                      then: '${repository.url}'
+                          repoUrl:
+                              $if: 'tasks_for == "github-push"'
+                              then: '${event.repository.html_url}'
+                              else:
+                                  $if: 'tasks_for == "github-pull-request"'
+                                  then: '${event.pull_request.head.repo.html_url}'
+                                  else:
+                                      $if: 'tasks_for in ["cron", "action"]'
+                                      then: '${repository.url}'
                       else:
-                          $if: 'tasks_for in ["cron", "action"]'
-                          then: '${ownTaskId}'
+                          baseRepoUrl:
+                              $if: 'tasks_for == "github-push"'
+                              then: '${event.repository.ssh_url}'
+                              else:
+                                  $if: 'tasks_for == "github-pull-request"'
+                                  then: '${event.pull_request.base.repo.ssh_url}'
+                                  else:
+                                      $if: 'tasks_for in ["cron", "action"]'
+                                      then: '${repository.url}'
+                          repoUrl:
+                              $if: 'tasks_for == "github-push"'
+                              then: '${event.repository.ssh_url}'
+                              else:
+                                  $if: 'tasks_for == "github-pull-request"'
+                                  then: '${event.pull_request.base.repo.ssh_url}'
+                                  else:
+                                      $if: 'tasks_for in ["cron", "action"]'
+                                      then: '${repository.url}'
               in:
                   $let:
                       level: 1
@@ -109,7 +141,7 @@ tasks:
                       metadata:
                           $merge:
                               - owner: "${ownerEmail}"
-                                source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
+                                source: 'https://github.com/${repoUrl[15:-4]}/raw/${head_sha}/.taskcluster.yml'
                               - $if: 'tasks_for in ["github-push", "github-pull-request"]'
                                 then:
                                     name: "Decision Task"
@@ -156,19 +188,22 @@ tasks:
                                           then: {$eval: 'head_branch[11:]'}
                                           else: ${head_branch}
                               in:
-                                  - 'assume:repo:${repoUrl[8:]}:branch:${short_head_branch}'
+                                  - 'assume:repo:github.com/${repoFullName}:branch:${short_head_branch}'
+
 
                           else:
                               $if: 'tasks_for == "github-pull-request"'
                               then:
-                                  - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request'
+                                  - 'assume:repo:github.com/${repoFullName}:pull-request'
+
                               else:
                                   $if: 'tasks_for == "action"'
                                   then:
                                       # when all actions are hooks, we can calculate this directly rather than using a variable
                                       - '${action.repo_scope}'
                                   else:
-                                      - 'assume:repo:${repoUrl[8:]}:cron:${cron.job_name}'
+                                      - 'assume:repo:github.com/${repoFullName}:cron:${cron.job_name}'
+
 
                       requires: all-completed
                       priority: lowest

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -5,6 +5,7 @@ task-priority: lowest
 
 taskgraph:
     register: xpi_taskgraph:register
+    decision-parameters: 'xpi_taskgraph.parameters:get_decision_parameters'
     repositories:
         xpi:
             name: "XPI source"

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -13,11 +13,8 @@ taskgraph:
         template:
             name: "XPI template"
             project-regex: 'xpi-template'
-            #XXX uncomment to merge
-            #default-repository: https://github.com/mozilla-extensions/xpi-template
-            #default-ref: master
-            default-repository: https://github.com/escapewindow/xpi-template
-            default-ref: private-ci
+            default-repository: https://github.com/mozilla-extensions/xpi-template
+            default-ref: master
             type: git
 
 workers:

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -12,8 +12,11 @@ taskgraph:
         template:
             name: "XPI template"
             project-regex: 'xpi-template'
-            default-repository: https://github.com/mozilla-extensions/xpi-template
-            default-ref: master
+            #XXX uncomment to merge
+            #default-repository: https://github.com/mozilla-extensions/xpi-template
+            #default-ref: master
+            default-repository: https://github.com/escapewindow/xpi-template
+            default-ref: private-ci
             type: git
 
 workers:

--- a/taskcluster/xpi_taskgraph/__init__.py
+++ b/taskcluster/xpi_taskgraph/__init__.py
@@ -15,6 +15,7 @@ def register(graph_config):
     _import_modules([
         "build",
         "cached",
+        "parameters",
         "single_dep",
         "test",
         "worker_types",

--- a/taskcluster/xpi_taskgraph/build.py
+++ b/taskcluster/xpi_taskgraph/build.py
@@ -32,8 +32,8 @@ def tasks_from_manifest(config, jobs):
             task["label"] = "build-{}".format(xpi_config["name"])
             env["XPI_NAME"] = xpi_config["name"]
             task.setdefault("extra", {})["xpi-name"] = xpi_config["name"]
-            if env.get("GITHUB_CLONE_SECRET", ""):
-                checkout_config["ssh_secret_name"] = env["GITHUB_CLONE_SECRET"]
+            if env.get("XPI_SSH_SECRET_NAME", ""):
+                checkout_config["ssh_secret_name"] = env["XPI_SSH_SECRET_NAME"]
                 artifact_prefix = "xpi/build"
             else:
                 artifact_prefix = "public/build"

--- a/taskcluster/xpi_taskgraph/parameters.py
+++ b/taskcluster/xpi_taskgraph/parameters.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import os
+import re
+
+from six import text_type
+from taskgraph.parameters import extend_parameters_schema
+from voluptuous import All, Any, Optional, Range, Required
+
+
+extend_parameters_schema({
+    Required("pull_request_number"): Any(All(int, Range(min=1)), None),
+    Required("release_type"): text_type,
+    Optional("shipping_phase"): Any('build', 'ship', None),
+    Required("version"): text_type,
+})
+
+
+def get_decision_parameters(graph_config, parameters):
+    """Add repo-specific decision parameters.
+
+    We don't have any repo-specific decision parameters, but we do need to
+    set repositories' `ssh-secret-name` if they're private repos. This seemed
+    to be the least objectionable place to add that.
+
+    """
+    for repo_prefix, repo_config in graph_config._config['taskgraph']['repositories'].items():
+        env_var = "{}_SSH_SECRET_NAME".format(repo_prefix.upper())
+        if os.environ.get(env_var):
+            repo_config.setdefault('ssh-secret-name', os.environ[env_var])

--- a/taskcluster/xpi_taskgraph/parameters.py
+++ b/taskcluster/xpi_taskgraph/parameters.py
@@ -5,19 +5,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import os
-import re
-
-from six import text_type
-from taskgraph.parameters import extend_parameters_schema
-from voluptuous import All, Any, Optional, Range, Required
-
-
-extend_parameters_schema({
-    Required("pull_request_number"): Any(All(int, Range(min=1)), None),
-    Required("release_type"): text_type,
-    Optional("shipping_phase"): Any('build', 'ship', None),
-    Required("version"): text_type,
-})
 
 
 def get_decision_parameters(graph_config, parameters):

--- a/taskcluster/xpi_taskgraph/test.py
+++ b/taskcluster/xpi_taskgraph/test.py
@@ -41,8 +41,8 @@ def test_tasks_from_manifest(config, jobs):
                     run["cwd"] = "{checkout}"
                 run["command"] = run["command"].format(target=target)
                 task["label"] = "t-{}-{}".format(target, xpi_name)
-                if env.get("GITHUB_CLONE_SECRET", ""):
-                    checkout_config["ssh_secret_name"] = env["GITHUB_CLONE_SECRET"]
+                if env.get("XPI_SSH_SECRET_NAME", ""):
+                    checkout_config["ssh_secret_name"] = env["XPI_SSH_SECRET_NAME"]
                     artifact_prefix = "xpi/build"
                 else:
                     artifact_prefix = "public/build"


### PR DESCRIPTION
Changes needed to add CI capabilities to private xpi repos, while keeping the automation running on public xpi repos.

I still need to get work done to verify CoT against private repos. I'm currently thinking I'll set the `source` to `ssh://...` to detect that we should get `.taskcluster.yml` via the github token, without requiring that we update `scriptworker.constants` every time we add a new private repo. That depends on https://github.com/taskcluster/taskcluster/pull/2812 .