### PR TITLE
Allow repositories to skip build and signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # XPI template repo
+
+## Special cases
+If a repository contains multiple `package.json` files, and any of them does not refer to an Add-on, a `dontbuild` file can be dropped in the directory to make automation skip building and signing.

--- a/taskcluster/xpi_taskgraph/xpi_manifest.py
+++ b/taskcluster/xpi_taskgraph/xpi_manifest.py
@@ -65,6 +65,13 @@ def get_manifest():
                 subdir_list.remove(dir_)
                 continue
         if "package.json" in file_list:
+            # The presence of a "package.json" file in the repository
+            # does not necessarily mean there's an addon to sign. We
+            # need to give the ability to repository owners to turn off
+            # signing for non-addon "package.json" (e.g. libraries).
+            if "dontbuild" in file_list:
+                continue
+
             manifest = {"tests": []}
             if "yarn.lock" in file_list:
                 manifest["install-type"] = "yarn"


### PR DESCRIPTION
This allows owners to put a `dontbuild` file in a directory containing a `package.json` file for which no build and sign
is required (for example, if the `package.json` refers to a library published through NPM).