### PR TITLE
Fix private artifact prefix

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -12,9 +12,7 @@ tasks:
           # `privileged` for AMO or self-hosted privileged add-on,
           # `mozillaonline-privileged` for Mozilla China add-on,
           # `normandy-privileged` for normandy add-on
-          # to enable siging on push/PR. Note, this only works for public repos
-          # for now. Release builds off shipit will get signing for both public
-          # and private repos.
+          # to enable siging on push/PR.
           xpiSigningType: ""
           # The below doesn't need changing on initial repo setup
           taskgraph:

--- a/taskcluster/xpi_taskgraph/build.py
+++ b/taskcluster/xpi_taskgraph/build.py
@@ -32,8 +32,7 @@ def tasks_from_manifest(config, jobs):
             task["label"] = "build-{}".format(xpi_config["name"])
             env["XPI_NAME"] = xpi_config["name"]
             task.setdefault("extra", {})["xpi-name"] = xpi_config["name"]
-            if env.get("XPI_SSH_SECRET_NAME", ""):
-                checkout_config["ssh_secret_name"] = env["XPI_SSH_SECRET_NAME"]
+            if os.environ.get("XPI_SSH_SECRET_NAME"):
                 artifact_prefix = "xpi/build"
             else:
                 artifact_prefix = "public/build"

--- a/taskcluster/xpi_taskgraph/build.py
+++ b/taskcluster/xpi_taskgraph/build.py
@@ -37,7 +37,7 @@ def tasks_from_manifest(config, jobs):
             else:
                 artifact_prefix = "public/build"
             task.setdefault("attributes", {})
-            task["attributes"]["artifact-prefix"] = artifact_prefix
+            task["attributes"]["artifact_prefix"] = artifact_prefix
             env["ARTIFACT_PREFIX"] = artifact_prefix
             artifacts = task["worker"].setdefault("artifacts", [])
             artifacts.append(

--- a/taskcluster/xpi_taskgraph/signing.py
+++ b/taskcluster/xpi_taskgraph/signing.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 
 from taskgraph.transforms.base import TransformSequence
-from taskgraph.util.taskcluster import get_artifact_prefix
 from taskgraph.util.schema import resolve_keyed_by
 from taskgraph.util.keyed_by import evaluate_keyed_by
 
@@ -58,11 +57,11 @@ def build_signing_task(config, tasks):
             continue
         dep = task["primary-dependency"]
         task["dependencies"] = {"build": dep.label}
-        artifact_prefix = get_artifact_prefix(dep.task)
+        artifact_prefix = dep.task["payload"]["env"]["ARTIFACT_PREFIX"].rstrip('/')
         if not artifact_prefix.startswith("public"):
             scopes = task.setdefault('scopes', [])
             scopes.append(
-                "queue:get-artifact:{}/*".format(dep.task["payload"]["env"]["ARTIFACT_PREFIX"].rstrip('/'))
+                "queue:get-artifact:{}/*".format(artifact_prefix)
             )
         xpi_name = dep.task["extra"]["xpi-name"]
         # XXX until we can figure out what to sign, assume

--- a/taskcluster/xpi_taskgraph/test.py
+++ b/taskcluster/xpi_taskgraph/test.py
@@ -41,8 +41,7 @@ def test_tasks_from_manifest(config, jobs):
                     run["cwd"] = "{checkout}"
                 run["command"] = run["command"].format(target=target)
                 task["label"] = "t-{}-{}".format(target, xpi_name)
-                if env.get("XPI_SSH_SECRET_NAME", ""):
-                    checkout_config["ssh_secret_name"] = env["XPI_SSH_SECRET_NAME"]
+                if os.environ.get("XPI_SSH_SECRET_NAME", ""):
                     artifact_prefix = "xpi/build"
                 else:
                     artifact_prefix = "public/build"


### PR DESCRIPTION
Fixes #20.
Fixes a potential way to leak information about private xpis. Also potentially fixes a question in #addons-pipeline.

This is one of those "how did this ever work" bugs.