### PR TITLE
reenable normandy privileged

### DIFF
--- a/taskcluster/xpi_taskgraph/signing.py
+++ b/taskcluster/xpi_taskgraph/signing.py
@@ -19,6 +19,8 @@ transforms = TransformSequence()
 
 FORMATS = {
     "mozillaonline-privileged": "privileged_webextension",
+    # normandy-privileged is deprecated
+    "normandy-privileged": "privileged_webextension",
     "privileged": "privileged_webextension",
     "system": "system_addon",
 }


### PR DESCRIPTION
See https://github.com/mozilla-releng/shipit/pull/1006 and https://github.com/mozilla-extensions/xpi-manifest/pull/150; essentially backs out #24 .