### PR TITLE
Add new linter kind to run addons-linter

### DIFF
--- a/taskcluster/ci/linter/kind.yml
+++ b/taskcluster/ci/linter/kind.yml
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+loader: xpi_taskgraph.single_dep:loader
+
+kind-dependencies:
+    - build
+
+transforms:
+    - xpi_taskgraph.linter:transforms
+    - taskgraph.transforms.job:transforms
+    - taskgraph.transforms.task:transforms
+
+job-template:
+    description: Run addons-linter
+    worker-type: b-linux
+    worker:
+        max-run-time: 7200
+        docker-image:
+            indexed: xpi.cache.level-3.docker-images.v2.node-16.latest
+        volumes:
+            - /builds/worker/checkouts
+    run:
+        using: run-task
+        cache-dotcache: false
+        checkout:
+            xpi: {}
+        use-caches: false
+        cwd: '{checkout}'
+        # TODO: We should enable MV3 when we are ready to accept MV3 add-ons.
+        # This should be done by replacing `2` with `3` in the command below.
+        command: >-
+            curl -sSL --fail -o {xpi_file} "$XPI_URL" &&
+            npx -y addons-linter --boring --disable-xpi-autoclose --max-manifest-version=2 {xpi_file}
+
+    attributes:
+        code-review: true

--- a/taskcluster/ci/pr/kind.yml
+++ b/taskcluster/ci/pr/kind.yml
@@ -7,6 +7,7 @@ loader: taskgraph.loader.transform:loader
 kind-dependencies:
     - build
     - test
+    - linter
 
 transforms:
     - taskgraph.transforms.code_review:transforms

--- a/taskcluster/xpi_taskgraph/linter.py
+++ b/taskcluster/xpi_taskgraph/linter.py
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Apply some defaults and minor modifications to the jobs defined in the build
+kind to run https://github.com/mozilla/addons-linter.
+"""
+
+
+import os
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+from taskgraph.util.keyed_by import evaluate_keyed_by
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def run_addons_linter(config, tasks):
+    for task in tasks:
+        dep = task.pop("primary-dependency")
+
+        # Add a dependency to the build task because we want to lint the
+        # generated XPI.
+        task["dependencies"] = {"build": dep.label}
+
+        artifact_prefix = dep.task["payload"]["env"]["ARTIFACT_PREFIX"].rstrip("/")
+        xpi_name = dep.task["extra"]["xpi-name"]
+        xpi_file = f"{xpi_name}.xpi"
+
+        # Set task label.
+        task["label"] = f"linter-{xpi_name}"
+
+        # Replace variables in the `command` to execute. We use an `env`
+        # variable for the `XPI_URL` to leverage `artifact-reference`.
+        env = task.setdefault("worker", {}).setdefault("env", {})
+
+        env["XPI_URL"] = {"artifact-reference": f"<build/{artifact_prefix}/{xpi_file}>"}
+        run = task["run"]
+        run["command"] = run["command"].format(xpi_file=xpi_file)
+
+        yield task


### PR DESCRIPTION
See: https://mozilla-hub.atlassian.net/browse/RELENG-575

---

Take it with a grain of salt, that was my very first time interacting with Taskgraph/TaskCluster...

This PR adds a new `linter` kind to execute the [addons-linter](https://github.com/mozilla/addons-linter) once XPIs are built, see: https://github.com/mozilla-extensions/proxy-monitor/pull/19 for an example. The addons-linter configuration is similar to [addons-server's one (AMO)](https://github.com/mozilla/addons-server/blob/45ec47958b23ace1967a6e0d02c64ba3565338f7/src/olympia/devhub/tasks.py#L440-L490).