### PR TITLE
Add '--retry 3' to curl command in linter kind

### DIFF
--- a/taskcluster/ci/linter/kind.yml
+++ b/taskcluster/ci/linter/kind.yml
@@ -32,7 +32,7 @@ job-template:
         # TODO: We should enable MV3 when we are ready to accept MV3 add-ons.
         # This should be done by replacing `2` with `3` in the command below.
         command: >-
-            curl -sSL --fail -o {xpi_file} "$XPI_URL" &&
+            curl -sSL --fail --retry 3 -o {xpi_file} "$XPI_URL" &&
             npx -y addons-linter --privileged --boring --disable-xpi-autoclose --max-manifest-version=2 {xpi_file}
 
     attributes:


### PR DESCRIPTION
This `curl` option should prevent download failures (backported from xpi-manifest).