### PR TITLE
linter: use node-20 docker image

### DIFF
--- a/taskcluster/ci/linter/kind.yml
+++ b/taskcluster/ci/linter/kind.yml
@@ -19,7 +19,7 @@ task-template:
     worker:
         max-run-time: 7200
         docker-image:
-            indexed: xpi.cache.level-3.docker-images.v2.node-16.latest
+            indexed: xpi.cache.level-3.docker-images.v2.node-20.latest
         volumes:
             - /builds/worker/checkouts
     run:


### PR DESCRIPTION
node 16 is EOL, and no longer supported by the addons linter.