### PR TITLE
fix: use gcp_prod signing formats

### DIFF
--- a/taskcluster/xpi_taskgraph/signing.py
+++ b/taskcluster/xpi_taskgraph/signing.py
@@ -17,11 +17,11 @@ from taskgraph.util.keyed_by import evaluate_keyed_by
 transforms = TransformSequence()
 
 FORMATS = {
-    "mozillaonline-privileged": "privileged_webextension",
+    "mozillaonline-privileged": "gcp_prod_privileged_webextension",
     # normandy-privileged is deprecated
-    "normandy-privileged": "privileged_webextension",
-    "privileged": "privileged_webextension",
-    "system": "system_addon",
+    "normandy-privileged": "gcp_prod_privileged_webextension",
+    "privileged": "gcp_prod_privileged_webextension",
+    "system": "gcp_prod_system_addon",
 }
 
 


### PR DESCRIPTION
We were supposed to switch to these weeks ago, but I missed this repo. The existing formats use AWS Autograph, which is going away soon.